### PR TITLE
Update open-ce-tests.yaml

### DIFF
--- a/tests/open-ce-tests.yaml
+++ b/tests/open-ce-tests.yaml
@@ -1,7 +1,7 @@
 tests:
   - name: Setup spaCy Tests
     command: |
-        conda install -y pytest>=4.6.5 pytest-timeout mock hypothesis
+        conda install -y pytest>=4.6.5 pytest-timeout mock hypothesis typing_extensions<4.6.0
   - name: Run spaCy tests
     command: |
         SPACY_LOCATION=$(python -c "import os; import spacy; print(os.path.dirname(spacy.__file__))")


### PR DESCRIPTION
Fixes issubclass error.  This was fixed in later versions of spaCy, but the addition here fixes it for this older version.
